### PR TITLE
Select controller by module name rather than adapter name

### DIFF
--- a/src/fastcs_odin/odin_controller.py
+++ b/src/fastcs_odin/odin_controller.py
@@ -56,8 +56,8 @@ class OdinController(Controller):
             )
             # Extract the module name of the adapter
             match response:
-                case {"module": module_data}:
-                    module = module_data["value"]
+                case {"module": {"value": str() as module}}:
+                    pass
                 case _:
                     raise ValueError(
                         f"Did not find valid module name in response:\n{response}"

--- a/src/fastcs_odin/odin_controller.py
+++ b/src/fastcs_odin/odin_controller.py
@@ -10,7 +10,7 @@ from fastcs_odin.odin_data import (
     FrameProcessorAdapterController,
     FrameReceiverAdapterController,
 )
-from fastcs_odin.util import OdinParameter, create_odin_parameters
+from fastcs_odin.util import AdapterType, OdinParameter, create_odin_parameters
 
 types = {"float": Float(), "int": Int(), "bool": Bool(), "str": String()}
 
@@ -24,10 +24,6 @@ class OdinController(Controller):
     """A root ``Controller`` for an odin control server."""
 
     API_PREFIX = "api/0.1"
-    MODULE_FRAME_PROCESSOR = "FrameProcessorAdapter"
-    MODULE_FRAME_RECEIVER = "FrameReceiverAdapter"
-    MODULE_META_WRITER = "MetaListenerAdapter"
-    MODULE_EIGER_FAN = "EigerFanAdapter"
 
     def __init__(self, settings: IPConnectionSettings) -> None:
         super().__init__()
@@ -81,19 +77,19 @@ class OdinController(Controller):
         """Create a sub controller for an adapter in an odin control server."""
 
         match module:
-            case self.MODULE_FRAME_PROCESSOR:
+            case AdapterType.FRAME_PROCESSOR:
                 return FrameProcessorAdapterController(
                     connection, parameters, f"{self.API_PREFIX}/{adapter}"
                 )
-            case self.MODULE_FRAME_RECEIVER:
+            case AdapterType.FRAME_RECEIVER:
                 return FrameReceiverAdapterController(
                     connection, parameters, f"{self.API_PREFIX}/{adapter}"
                 )
-            case self.MODULE_META_WRITER:
+            case AdapterType.META_WRITER:
                 return MetaWriterAdapterController(
                     connection, parameters, f"{self.API_PREFIX}/{adapter}"
                 )
-            case self.MODULE_EIGER_FAN:
+            case AdapterType.EIGER_FAN:
                 return EigerFanAdapterController(
                     connection, parameters, f"{self.API_PREFIX}/{adapter}"
                 )

--- a/src/fastcs_odin/util.py
+++ b/src/fastcs_odin/util.py
@@ -1,10 +1,18 @@
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any, TypeVar
 
 
 def is_metadata_object(v: Any) -> bool:
     return isinstance(v, dict) and "writeable" in v and "type" in v
+
+
+class AdapterType(str, Enum):
+    FRAME_PROCESSOR = "FrameProcessorAdapter"
+    FRAME_RECEIVER = "FrameReceiverAdapter"
+    META_WRITER = "MetaListenerAdapter"
+    EIGER_FAN = "EigerFanAdapter"
 
 
 @dataclass

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -27,7 +27,7 @@ from fastcs_odin.odin_data import (
     FrameReceiverController,
     FrameReceiverDecoderController,
 )
-from fastcs_odin.util import OdinParameter
+from fastcs_odin.util import AdapterType, OdinParameter
 
 HERE = Path(__file__).parent
 
@@ -81,22 +81,22 @@ async def test_create_adapter_controller(mocker: MockerFixture):
     parameters = [OdinParameter(["0"], metadata={})]
 
     ctrl = controller._create_adapter_controller(
-        controller.connection, parameters, "fp", "FrameProcessorAdapter"
+        controller.connection, parameters, "fp", AdapterType.FRAME_PROCESSOR
     )
     assert isinstance(ctrl, FrameProcessorAdapterController)
 
     ctrl = controller._create_adapter_controller(
-        controller.connection, parameters, "fr", "FrameReceiverAdapter"
+        controller.connection, parameters, "fr", AdapterType.FRAME_RECEIVER
     )
     assert isinstance(ctrl, FrameReceiverAdapterController)
 
     ctrl = controller._create_adapter_controller(
-        controller.connection, parameters, "mw", "MetaListenerAdapter"
+        controller.connection, parameters, "mw", AdapterType.META_WRITER
     )
     assert isinstance(ctrl, MetaWriterAdapterController)
 
     ctrl = controller._create_adapter_controller(
-        controller.connection, parameters, "ef", "EigerFanAdapter"
+        controller.connection, parameters, "ef", AdapterType.EIGER_FAN
     )
     assert isinstance(ctrl, EigerFanAdapterController)
 

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -78,29 +78,30 @@ def test_fp_process_parameters():
 async def test_create_adapter_controller(mocker: MockerFixture):
     controller = OdinController(IPConnectionSettings("", 0))
     controller.connection = mocker.AsyncMock()
+    parameters = [OdinParameter(["0"], metadata={})]
 
     ctrl = controller._create_adapter_controller(
-        controller.connection, None, "fp", "FrameProcessorAdapter"
+        controller.connection, parameters, "fp", "FrameProcessorAdapter"
     )
     assert isinstance(ctrl, FrameProcessorAdapterController)
 
     ctrl = controller._create_adapter_controller(
-        controller.connection, None, "fr", "FrameReceiverAdapter"
+        controller.connection, parameters, "fr", "FrameReceiverAdapter"
     )
     assert isinstance(ctrl, FrameReceiverAdapterController)
 
     ctrl = controller._create_adapter_controller(
-        controller.connection, None, "mw", "MetaListenerAdapter"
+        controller.connection, parameters, "mw", "MetaListenerAdapter"
     )
     assert isinstance(ctrl, MetaWriterAdapterController)
 
     ctrl = controller._create_adapter_controller(
-        controller.connection, None, "ef", "EigerFanAdapter"
+        controller.connection, parameters, "ef", "EigerFanAdapter"
     )
     assert isinstance(ctrl, EigerFanAdapterController)
 
     ctrl = controller._create_adapter_controller(
-        controller.connection, None, "od", "OtherAdapter"
+        controller.connection, parameters, "od", "OtherAdapter"
     )
     assert isinstance(ctrl, OdinAdapterController)
 


### PR DESCRIPTION
Adapters can be given any name, but the module name is fixed by the adapter class itself.
It is better to select the fastcs controller according to the module name rather then the assigned adapter name.

Fixes #29
Fixes #23 