### PR TITLE
Fix OdinParameter name generation

### DIFF
--- a/src/fastcs_odin/util.py
+++ b/src/fastcs_odin/util.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, TypeVar
 
 from fastcs.controller import BaseController, SubController
 from fastcs.datatypes import Bool, DataType, Float, Int, String
+from pvi.device import enforce_pascal_case
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 
@@ -58,7 +59,7 @@ class OdinParameter:
     @property
     def name(self) -> str:
         """Unique name of parameter."""
-        return "_".join(self.path).replace("-", "")
+        return enforce_pascal_case("_".join(self.path))
 
     def set_path(self, path: list[str]):
         """Set reduced path of parameter to override uri when constructing name."""

--- a/src/fastcs_odin/util.py
+++ b/src/fastcs_odin/util.py
@@ -58,7 +58,7 @@ class OdinParameter:
     @property
     def name(self) -> str:
         """Unique name of parameter."""
-        return "_".join(self.path)
+        return "_".join(self.path).replace("-", "")
 
     def set_path(self, path: list[str]):
         """Set reduced path of parameter to override uri when constructing name."""

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -52,9 +52,9 @@ def test_create_attributes():
 
     match controller.attributes:
         case {
-            "read_int": AttrR(datatype=Int()),
-            "write_bool": AttrRW(datatype=Bool()),
-            "group_float": AttrR(datatype=Float(), group="Group"),
+            "Readint": AttrR(datatype=Int()),
+            "Writebool": AttrRW(datatype=Bool()),
+            "Groupfloat": AttrR(datatype=Float(), group="Group"),
         }:
             pass
         case _:

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -103,7 +103,7 @@ def test_nested_node_gives_correct_name():
     data = {"top": {"nest-1": {"nest-2": 1}}}
     parameters = create_odin_parameters(data)
     assert len(parameters) == 1
-    assert parameters[0].name == "top_nest-1_nest-2"
+    assert parameters[0].name == "top_nest1_nest2"
 
 
 def test_config_node_splits_list_into_mutiples():

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -89,7 +89,7 @@ async def test_fr_initialise(mocker: MockerFixture):
 def test_node_with_empty_list_is_correctly_counted():
     parameters = create_odin_parameters({"test": []})
     names = [p.name for p in parameters]
-    assert "test" in names
+    assert "Test" in names
     assert len(parameters) == 1
 
 
@@ -103,7 +103,7 @@ def test_nested_node_gives_correct_name():
     data = {"top": {"nest-1": {"nest-2": 1}}}
     parameters = create_odin_parameters(data)
     assert len(parameters) == 1
-    assert parameters[0].name == "top_nest1_nest2"
+    assert parameters[0].name == "Topnest1nest2"
 
 
 def test_config_node_splits_list_into_mutiples():


### PR DESCRIPTION
I've made this change to address the problems when trying to create parameters that have the "-" character in their name. This causes problems when generating screens and can make some PV names be way too long. 