### PR TITLE
Fallback to using the default adapter controller when no module in API

### DIFF
--- a/src/fastcs_odin/odin_controller.py
+++ b/src/fastcs_odin/odin_controller.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastcs.connections.ip_connection import IPConnectionSettings
 from fastcs.controller import Controller
 from fastcs.datatypes import Bool, Float, Int, String
@@ -60,7 +62,7 @@ class OdinController(Controller):
             )
             self.register_sub_controller(adapter.upper(), adapter_controller)
             await adapter_controller.initialise()
-
+        await asyncio.sleep(5)
         await self.connection.close()
 
     def _create_adapter_controller(

--- a/src/fastcs_odin/odin_controller.py
+++ b/src/fastcs_odin/odin_controller.py
@@ -53,9 +53,7 @@ class OdinController(Controller):
                 case {"module": {"value": str() as module}}:
                     pass
                 case _:
-                    raise ValueError(
-                        f"Did not find valid module name in response:\n{response}"
-                    )
+                    module = ""
 
             adapter_controller = self._create_adapter_controller(
                 self.connection, create_odin_parameters(response), adapter, module

--- a/src/fastcs_odin/odin_controller.py
+++ b/src/fastcs_odin/odin_controller.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from fastcs.connections.ip_connection import IPConnectionSettings
 from fastcs.controller import Controller
 from fastcs.datatypes import Bool, Float, Int, String
@@ -62,7 +60,7 @@ class OdinController(Controller):
             )
             self.register_sub_controller(adapter.upper(), adapter_controller)
             await adapter_controller.initialise()
-        await asyncio.sleep(5)
+
         await self.connection.close()
 
     def _create_adapter_controller(

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -140,8 +140,7 @@ async def test_given_no_module_create_adapter_controller_succeeds(
         {"": {"value": "test_module"}},
     ]
 
-    async with mocker.patch("asyncio.sleep", return_value=None):
-        await controller.initialise()
+    await controller.initialise()
 
 
 @pytest.mark.asyncio

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -148,7 +148,6 @@ async def test_controller_initialise(
 ):
     controller = OdinController(IPConnectionSettings("", 0))
 
-    controller.register_sub_controller = mocker.MagicMock()
     controller.connection = mocker.AsyncMock()
     controller.connection.open = mocker.MagicMock()
 
@@ -157,8 +156,7 @@ async def test_controller_initialise(
     await controller.initialise()
 
     assert isinstance(
-        controller.register_sub_controller.call_args_list[0][0][1],
-        expected_controller,
+        controller.get_sub_controllers()["TEST_ADAPTER"], expected_controller
     )
 
 

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -125,6 +125,11 @@ async def test_create_adapter_controller(mocker: MockerFixture):
     )
     assert isinstance(ctrl, OdinAdapterController)
 
+    ctrl = controller._create_adapter_controller(
+        controller.connection, parameters, "od", ""
+    )
+    assert isinstance(ctrl, OdinAdapterController)
+
 
 @pytest.mark.asyncio
 async def test_fp_create_plugin_sub_controllers():

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -127,7 +127,7 @@ async def test_create_adapter_controller(mocker: MockerFixture):
 
 
 @pytest.mark.asyncio
-async def test_create_adapter_controller_given_no_module_succeeds(
+async def test_given_no_module_create_adapter_controller_succeeds(
     mocker: MockerFixture,
 ):
     controller = OdinController(IPConnectionSettings("", 0))

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -127,6 +127,24 @@ async def test_create_adapter_controller(mocker: MockerFixture):
 
 
 @pytest.mark.asyncio
+async def test_create_adapter_controller_given_no_module_succeeds(
+    mocker: MockerFixture,
+):
+    controller = OdinController(IPConnectionSettings("", 0))
+
+    controller.connection = mocker.AsyncMock()
+    controller.connection.open = mocker.MagicMock()
+
+    controller.connection.get.side_effect = [
+        {"adapters": ["adapter1"]},
+        {"": {"value": "test_module"}},
+    ]
+
+    async with mocker.patch("asyncio.sleep", return_value=None):
+        await controller.initialise()
+
+
+@pytest.mark.asyncio
 async def test_fp_create_plugin_sub_controllers():
     parameters = [
         OdinParameter(

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -125,11 +125,6 @@ async def test_create_adapter_controller(mocker: MockerFixture):
     )
     assert isinstance(ctrl, OdinAdapterController)
 
-    ctrl = controller._create_adapter_controller(
-        controller.connection, parameters, "od", ""
-    )
-    assert isinstance(ctrl, OdinAdapterController)
-
 
 @pytest.mark.asyncio
 async def test_fp_create_plugin_sub_controllers():


### PR DESCRIPTION
Fixes #60, and Fixes #22 

This PR sets `module = ""` if no module found; A test is also written for `controller.initialise()`