### PR TITLE
Command introspection

### DIFF
--- a/src/fastcs_odin/frame_processor.py
+++ b/src/fastcs_odin/frame_processor.py
@@ -10,7 +10,7 @@ from fastcs_odin.odin_adapter_controller import (
     StatusSummaryUpdater,
 )
 from fastcs_odin.odin_data import OdinDataAdapterController, OdinDataController
-from fastcs_odin.util import OdinParameter, partition
+from fastcs_odin.util import AllowedCommandResponse, OdinParameter, partition
 
 
 class FrameProcessorController(OdinDataController):
@@ -102,11 +102,10 @@ class FrameProcessorPluginController(OdinAdapterController):
         command_response = await self.connection.get(
             f"{self._api_prefix}/{command_path}/allowed"
         )
-        if "allowed" in command_response:
-            command_names = command_response["allowed"]
-            assert isinstance(command_names, list)
-            for command_name in command_names:
-                self.construct_command(command_name, command_path)
+
+        commands = AllowedCommandResponse.model_validate(command_response)
+        for command in commands.allowed:
+            self.construct_command(command, command_path)
 
     def construct_command(self, command_name, command_path):
         async def submit_command() -> None:

--- a/src/fastcs_odin/frame_processor.py
+++ b/src/fastcs_odin/frame_processor.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from fastcs.attributes import AttrR
 from fastcs.cs_methods import Command
 from fastcs.datatypes import Bool, Int
+from pydantic import ValidationError
 
 from fastcs_odin.odin_adapter_controller import (
     OdinAdapterController,
@@ -103,9 +104,12 @@ class FrameProcessorPluginController(OdinAdapterController):
             f"{self._api_prefix}/{command_path}/allowed"
         )
 
-        commands = AllowedCommandResponse.model_validate(command_response)
-        for command in commands.allowed:
-            self.construct_command(command, command_path)
+        try:
+            commands = AllowedCommandResponse.model_validate(command_response)
+            for command in commands.allowed:
+                self.construct_command(command, command_path)
+        except ValidationError:
+            pass
 
     def construct_command(self, command_name, command_path):
         async def submit_command() -> None:

--- a/src/fastcs_odin/odin_adapter_controller.py
+++ b/src/fastcs_odin/odin_adapter_controller.py
@@ -13,7 +13,6 @@ from fastcs.attributes import (
     AttrW,
 )
 from fastcs.controller import BaseController, SubController
-from fastcs.cs_methods import Command
 from fastcs.util import snake_to_pascal
 
 from fastcs_odin.http_connection import HTTPConnection
@@ -201,19 +200,6 @@ class OdinAdapterController(SubController):
     async def initialise(self):
         self._process_parameters()
         self._create_attributes()
-        await self._create_commands()
-
-    async def _create_commands(self):
-        if len(self.path) == 3:
-            command_path = f"command/{self.path[2].lower()}"
-            command_response = await self.connection.get(
-                f"{self._api_prefix}/{command_path}/allowed"
-            )
-            if "allowed" in command_response:
-                command_names = command_response["allowed"]
-                assert isinstance(command_names, list)
-                for command_name in command_names:
-                    self.construct_command(command_name, command_path)
 
     def _process_parameters(self):
         """Hook to process ``OdinParameters`` before creating ``Attributes``.
@@ -222,14 +208,6 @@ class OdinAdapterController(SubController):
 
         """
         pass
-
-    def construct_command(self, command_name, command_path):
-        async def submit_command() -> None:
-            await self.connection.put(
-                f"{self._api_prefix}/{command_path}/execute", command_name
-            )
-
-        setattr(self, command_name, Command(submit_command))
 
     def _create_attributes(self):
         """Create controller ``Attributes`` from ``OdinParameters``."""

--- a/src/fastcs_odin/odin_adapter_controller.py
+++ b/src/fastcs_odin/odin_adapter_controller.py
@@ -13,6 +13,7 @@ from fastcs.attributes import (
     AttrW,
 )
 from fastcs.controller import BaseController, SubController
+from fastcs.cs_methods import Command
 from fastcs.util import snake_to_pascal
 
 from fastcs_odin.http_connection import HTTPConnection
@@ -200,6 +201,19 @@ class OdinAdapterController(SubController):
     async def initialise(self):
         self._process_parameters()
         self._create_attributes()
+        await self._create_commands()
+
+    async def _create_commands(self):
+        if len(self.path) == 3:
+            command_path = f"command/{self.path[2].lower()}"
+            command_response = await self.connection.get(
+                f"{self._api_prefix}/{command_path}/allowed"
+            )
+            if "allowed" in command_response:
+                command_names = command_response["allowed"]
+                assert isinstance(command_names, list)
+                for command_name in command_names:
+                    self.construct_command(command_name, command_path)
 
     def _process_parameters(self):
         """Hook to process ``OdinParameters`` before creating ``Attributes``.
@@ -208,6 +222,14 @@ class OdinAdapterController(SubController):
 
         """
         pass
+
+    def construct_command(self, command_name, command_path):
+        async def submit_command() -> None:
+            await self.connection.put(
+                f"{self._api_prefix}/{command_path}/execute", command_name
+            )
+
+        setattr(self, command_name, Command(submit_command))
 
     def _create_attributes(self):
         """Create controller ``Attributes`` from ``OdinParameters``."""

--- a/src/fastcs_odin/util.py
+++ b/src/fastcs_odin/util.py
@@ -44,7 +44,6 @@ class OdinParameterMetadata(BaseModel):
 class AllowedCommandResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
     allowed: list[str]
-    execute: str
 
 
 @dataclass

--- a/src/fastcs_odin/util.py
+++ b/src/fastcs_odin/util.py
@@ -139,7 +139,10 @@ def _walk_odin_metadata(
                     # TODO: This won't be needed when all parameters provide metadata
                     yield (node_path, infer_metadata(node_value, node_path))
             except ValidationError as e:
-                logging.warning(f"Type not supported:\n{e}")
+                logging.warning(
+                    f"Type not supported for path {node_path} "
+                    f"with value {node_value}:\n{e}"
+                )
 
 
 def infer_metadata(parameter: Any, uri: list[str]):

--- a/src/fastcs_odin/util.py
+++ b/src/fastcs_odin/util.py
@@ -41,7 +41,7 @@ class OdinParameterMetadata(BaseModel):
                 return String()
 
 
-class AllowedCommandResponse(BaseModel):
+class AllowedCommandsResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
     allowed: list[str]
 

--- a/src/fastcs_odin/util.py
+++ b/src/fastcs_odin/util.py
@@ -97,43 +97,53 @@ def _walk_odin_metadata(
     for node_name, node_value in tree.items():
         node_path = path + [node_name]
 
-        # Branches - dict or list[dict] to recurse through
-        if isinstance(node_value, dict) and not is_metadata_object(node_value):
-            yield from _walk_odin_metadata(node_value, node_path)
-        elif (
-            isinstance(node_value, list)
-            and node_value  # Exclude parameters with an empty list as a value
-            and all(isinstance(m, dict) for m in node_value)
+        if "command" in node_path and (
+            "allowed" in node_path or "execute" in node_path
         ):
-            for idx, sub_node in enumerate(node_value):
-                sub_node_path = node_path + [str(idx)]
-                yield from _walk_odin_metadata(sub_node, sub_node_path)
+            # Do not parse and yield any command attributes
+            # They are handled by the individual controllers
+            pass
         else:
-            # Leaves
-            try:
-                if isinstance(node_value, dict) and is_metadata_object(node_value):
-                    yield (node_path, OdinParameterMetadata.model_validate(node_value))
-                elif isinstance(node_value, list):
-                    if "config" in node_path:
-                        # Split list into separate parameters so they can be set
-                        for idx, sub_node_value in enumerate(node_value):
-                            sub_node_path = node_path + [str(idx)]
+            # Branches - dict or list[dict] to recurse through
+            if isinstance(node_value, dict) and not is_metadata_object(node_value):
+                yield from _walk_odin_metadata(node_value, node_path)
+            elif (
+                isinstance(node_value, list)
+                and node_value  # Exclude parameters with an empty list as a value
+                and all(isinstance(m, dict) for m in node_value)
+            ):
+                for idx, sub_node in enumerate(node_value):
+                    sub_node_path = node_path + [str(idx)]
+                    yield from _walk_odin_metadata(sub_node, sub_node_path)
+            else:
+                # Leaves
+                try:
+                    if isinstance(node_value, dict) and is_metadata_object(node_value):
+                        yield (
+                            node_path,
+                            OdinParameterMetadata.model_validate(node_value),
+                        )
+                    elif isinstance(node_value, list):
+                        if "config" in node_path:
+                            # Split list into separate parameters so they can be set
+                            for idx, sub_node_value in enumerate(node_value):
+                                sub_node_path = node_path + [str(idx)]
+                                yield (
+                                    sub_node_path,
+                                    infer_metadata(sub_node_value, sub_node_path),
+                                )
+                        else:
+                            # Convert read-only list to a string for display
                             yield (
-                                sub_node_path,
-                                infer_metadata(sub_node_value, sub_node_path),
+                                node_path,
+                                infer_metadata(str(node_value), node_path),
                             )
-                    else:
-                        # Convert read-only list to a string for display
-                        yield (node_path, infer_metadata(str(node_value), node_path))
 
-                else:
-                    # TODO: This won't be needed when all parameters provide metadata
-                    yield (node_path, infer_metadata(node_value, node_path))
-            except ValidationError as e:
-                logging.warning(
-                    f"Type not supported for path {node_path} "
-                    f"with value {node_value}:\n{e}"
-                )
+                    else:
+                        # TODO: This won't be needed when all parameters provide metadata
+                        yield (node_path, infer_metadata(node_value, node_path))
+                except ValidationError as e:
+                    logging.warning(f"Type not supported:\n{e}")
 
 
 def infer_metadata(parameter: Any, uri: list[str]):

--- a/src/fastcs_odin/util.py
+++ b/src/fastcs_odin/util.py
@@ -97,9 +97,7 @@ def _walk_odin_metadata(
     for node_name, node_value in tree.items():
         node_path = path + [node_name]
 
-        if "command" in node_path and (
-            "allowed" in node_path or "execute" in node_path
-        ):
+        if "command" in node_path:
             # Do not parse and yield any command attributes
             # They are handled by the individual controllers
             continue
@@ -118,10 +116,7 @@ def _walk_odin_metadata(
             # Leaves
             try:
                 if isinstance(node_value, dict) and is_metadata_object(node_value):
-                    yield (
-                        node_path,
-                        OdinParameterMetadata.model_validate(node_value),
-                    )
+                    yield (node_path, OdinParameterMetadata.model_validate(node_value))
                 elif isinstance(node_value, list):
                     if "config" in node_path:
                         # Split list into separate parameters so they can be set
@@ -133,10 +128,7 @@ def _walk_odin_metadata(
                             )
                     else:
                         # Convert read-only list to a string for display
-                        yield (
-                            node_path,
-                            infer_metadata(str(node_value), node_path),
-                        )
+                        yield (node_path, infer_metadata(str(node_value), node_path))
 
                 else:
                     # TODO: This won't be needed when all parameters provide metadata

--- a/src/fastcs_odin/util.py
+++ b/src/fastcs_odin/util.py
@@ -41,6 +41,12 @@ class OdinParameterMetadata(BaseModel):
                 return String()
 
 
+class AllowedCommandResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    allowed: list[str]
+    execute: str
+
+
 @dataclass
 class OdinParameter:
     uri: list[str]

--- a/tests/input/one_node_fp_response.json
+++ b/tests/input/one_node_fp_response.json
@@ -185,6 +185,19 @@
                     }
                 }
             }
+        },
+        "command": {
+            "dummy": {
+                "allowed": [],
+                "execute": ""
+            },
+            "hdf": {
+                "allowed": [
+                    "command1",
+                    "command2"
+                ],
+                "execute": ""
+            }
         }
     }
 }

--- a/tests/input/two_node_fp_response.json
+++ b/tests/input/two_node_fp_response.json
@@ -197,6 +197,19 @@
                     }
                 }
             }
+        },
+        "command": {
+            "dummy": {
+                "allowed": [],
+                "execute": ""
+            },
+            "hdf": {
+                "allowed": [
+                    "command1",
+                    "command2"
+                ],
+                "execute": ""
+            }
         }
     },
     "1": {
@@ -350,6 +363,19 @@
                         "input": ""
                     }
                 }
+            }
+        },
+        "command": {
+            "dummy": {
+                "allowed": [],
+                "execute": ""
+            },
+            "hdf": {
+                "allowed": [
+                    "command1",
+                    "command2"
+                ],
+                "execute": ""
             }
         }
     }

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -1,4 +1,3 @@
-import json
 import re
 from pathlib import Path
 

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -69,7 +69,7 @@ async def test_create_commands(mocker: MockerFixture):
         response = json.loads(f.read())
 
     mock_connection.get.side_effect = [
-        response[str(0)]["command"]["hdf"],
+        {"allowed": response[str(0)]["command"]["hdf"]["allowed"]},
     ]
 
     controller = FrameProcessorPluginController(mock_connection, [], "api/0.1")
@@ -188,7 +188,7 @@ async def test_fp_create_plugin_sub_controllers(mocker: MockerFixture):
         response = json.loads(f.read())
 
     mock_connection.get.side_effect = [
-        response[str(0)]["command"]["hdf"],
+        {"allowed": response[str(0)]["command"]["hdf"]["allowed"]},
     ]
 
     parameters = [

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -1,3 +1,4 @@
+import json
 import re
 from pathlib import Path
 
@@ -59,6 +60,26 @@ def test_create_attributes():
             pass
         case _:
             pytest.fail("Controller Attributes not as expected")
+
+
+@pytest.mark.asyncio
+async def test_create_commands(mocker: MockerFixture):
+    mock_connection = mocker.AsyncMock()
+    with (HERE / "input/two_node_fp_response.json").open() as f:
+        response = json.loads(f.read())
+
+    mock_connection.get.side_effect = [
+        response[str(0)]["command"]["hdf"],
+    ]
+
+    controller = FrameProcessorPluginController(mock_connection, [], "api/0.1")
+    controller._path = ["hdf"]
+
+    await controller._create_commands()
+
+    # Call the command methods that have been bound to the controller
+    await controller.command1()  # type: ignore
+    await controller.command2()  # type: ignore
 
 
 def test_fp_process_parameters():
@@ -163,6 +184,12 @@ async def test_controller_initialise(
 @pytest.mark.asyncio
 async def test_fp_create_plugin_sub_controllers(mocker: MockerFixture):
     mock_connection = mocker.AsyncMock()
+    with (HERE / "input/two_node_fp_response.json").open() as f:
+        response = json.loads(f.read())
+
+    mock_connection.get.side_effect = [
+        response[str(0)]["command"]["hdf"],
+    ]
 
     parameters = [
         OdinParameter(

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -1,3 +1,4 @@
+import json
 import re
 from pathlib import Path
 
@@ -161,7 +162,9 @@ async def test_controller_initialise(
 
 
 @pytest.mark.asyncio
-async def test_fp_create_plugin_sub_controllers():
+async def test_fp_create_plugin_sub_controllers(mocker: MockerFixture):
+    mock_connection = mocker.AsyncMock()
+
     parameters = [
         OdinParameter(
             uri=["config", "ctrl_endpoint"],
@@ -180,7 +183,7 @@ async def test_fp_create_plugin_sub_controllers():
         ),
     ]
 
-    fpc = FrameProcessorController(HTTPConnection("", 0), parameters, "api/0.1")
+    fpc = FrameProcessorController(mock_connection, parameters, "api/0.1")
 
     await fpc._create_plugin_sub_controllers(["hdf"])
 

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -70,6 +70,7 @@ async def test_create_commands(mocker: MockerFixture):
 
     mock_connection.get.side_effect = [
         {"allowed": response[str(0)]["command"]["hdf"]["allowed"]},
+        {"response": "No commands, path invalid"},
     ]
 
     controller = FrameProcessorPluginController(mock_connection, [], "api/0.1")
@@ -80,6 +81,11 @@ async def test_create_commands(mocker: MockerFixture):
     # Call the command methods that have been bound to the controller
     await controller.command1()  # type: ignore
     await controller.command2()  # type: ignore
+
+    controller = FrameProcessorPluginController(mock_connection, [], "api/0.1")
+    controller._path = ["offset"]
+
+    await controller._create_commands()
 
 
 def test_fp_process_parameters():

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -48,8 +48,22 @@ async def test_fp_initialise(mocker: MockerFixture):
     async def get_plugins(idx: int):
         return response[str(idx)]["status"]["plugins"]
 
+    async def get_commands(idx: int):
+        return response[str(idx)]["command"]["hdf"]
+
     mock_connection = mocker.MagicMock()
-    mock_connection.get.side_effect = [get_plugins(0), get_plugins(1)]
+    mock_connection.get.side_effect = [
+        get_plugins(0),
+        get_commands(0),
+        get_commands(0),
+        get_commands(0),
+        get_commands(0),
+        get_plugins(1),
+        get_commands(1),
+        get_commands(1),
+        get_commands(1),
+        get_commands(1),
+    ]
 
     parameters = create_odin_parameters(response)
     controller = FrameProcessorAdapterController(mock_connection, parameters, "prefix")

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -31,6 +31,10 @@ def test_one_node_fp():
     parameters = create_odin_parameters(response)
     assert len(parameters) == 97
 
+    # Assert no command parameters are created
+    for param in parameters:
+        assert "command" not in param.uri
+
 
 def test_two_node_fp():
     with (HERE / "input/two_node_fp_response.json").open() as f:
@@ -38,6 +42,10 @@ def test_two_node_fp():
 
     parameters = create_odin_parameters(response)
     assert len(parameters) == 190
+
+    # Assert no command parameters are created
+    for param in parameters:
+        assert "command" not in param.uri
 
 
 @pytest.mark.asyncio

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -57,7 +57,7 @@ async def test_fp_initialise(mocker: MockerFixture):
         return response[str(idx)]["status"]["plugins"]
 
     async def get_commands(idx: int):
-        return response[str(idx)]["command"]["hdf"]
+        return {"allowed": response[str(idx)]["command"]["hdf"]["allowed"]}
 
     mock_connection = mocker.MagicMock()
     mock_connection.get.side_effect = [


### PR DESCRIPTION
This PR stops command URIs from being autogenerated into standard attributes.
It then builds Command objects for each command listed within the "allowed" commands endpoint.

Fixes #41 
Fixes #68 - the failing parameters are `command/.../allowed`, so this will fix the problem