### PR TITLE
Add top level writing attribute

### DIFF
--- a/src/fastcs_odin/odin_adapter_controller.py
+++ b/src/fastcs_odin/odin_adapter_controller.py
@@ -84,7 +84,7 @@ class StatusSummaryUpdater(AttrHandlerR):
         attribute and returns a summary value.
     """
 
-    path_filter: list[str | tuple[str] | re.Pattern]
+    path_filter: list[str | tuple[str, ...] | re.Pattern]
     attribute_name: str
     accumulator: Callable[[Iterable[Any]], float | int | bool | str]
     update_period: float | None = 0.2
@@ -122,37 +122,43 @@ class ConfigFanSender(AttrHandlerW):
 
 
 def _filter_sub_controllers(
-    controller: BaseController, path_filter: Sequence[str | tuple[str] | re.Pattern]
+    controller: BaseController,
+    path_filter: Sequence[str | tuple[str, ...] | re.Pattern],
 ) -> Iterable[SubController]:
     sub_controller_map = controller.get_sub_controllers()
-
-    if len(path_filter) == 1:
-        assert isinstance(path_filter[0], str)
-        yield sub_controller_map[path_filter[0]]
-        return
-
     step = path_filter[0]
+    is_leaf = len(path_filter) == 1
+
     match step:
         case str() as key:
             if key not in sub_controller_map:
                 raise ValueError(f"SubController {key} not found in {controller}")
+            sub_controller = sub_controller_map[key]
+            if is_leaf:
+                yield sub_controller
+            else:
+                yield from _filter_sub_controllers(sub_controller, path_filter[1:])
 
-            sub_controllers = (sub_controller_map[key],)
         case tuple() as keys:
             for key in keys:
                 if key not in sub_controller_map:
                     raise ValueError(f"SubController {key} not found in {controller}")
+                sub_controller = sub_controller_map[key]
+                if is_leaf:
+                    yield sub_controller
+                else:
+                    yield from _filter_sub_controllers(sub_controller, path_filter[1:])
 
-            sub_controllers = tuple(sub_controller_map[k] for k in keys)
         case pattern:
-            sub_controllers = tuple(
-                sub_controller_map[k]
-                for k in sub_controller_map.keys()
-                if pattern.match(k)
-            )
-
-    for sub_controller in sub_controllers:
-        yield from _filter_sub_controllers(sub_controller, path_filter[1:])
+            for key in sub_controller_map:
+                if pattern.match(key):
+                    sub_controller = sub_controller_map[key]
+                    if is_leaf:
+                        yield sub_controller
+                    else:
+                        yield from _filter_sub_controllers(
+                            sub_controller, path_filter[1:]
+                        )
 
 
 class OdinAdapterController(SubController):

--- a/src/fastcs_odin/odin_controller.py
+++ b/src/fastcs_odin/odin_controller.py
@@ -1,3 +1,4 @@
+from fastcs.attributes import AttrR
 from fastcs.connections.ip_connection import IPConnectionSettings
 from fastcs.controller import Controller
 from fastcs.datatypes import Bool, Float, Int, String
@@ -7,7 +8,10 @@ from fastcs_odin.frame_processor import FrameProcessorAdapterController
 from fastcs_odin.frame_receiver import FrameReceiverAdapterController
 from fastcs_odin.http_connection import HTTPConnection
 from fastcs_odin.meta_writer import MetaWriterAdapterController
-from fastcs_odin.odin_adapter_controller import OdinAdapterController
+from fastcs_odin.odin_adapter_controller import (
+    OdinAdapterController,
+    StatusSummaryUpdater,
+)
 from fastcs_odin.util import AdapterType, OdinParameter, create_odin_parameters
 
 types = {"float": Float(), "int": Int(), "bool": Bool(), "str": String()}
@@ -22,6 +26,10 @@ class OdinController(Controller):
     """A root ``Controller`` for an odin control server."""
 
     API_PREFIX = "api/0.1"
+
+    writing: AttrR = AttrR(
+        Bool(), handler=StatusSummaryUpdater([("MW", "FP")], "writing", any)
+    )
 
     def __init__(self, settings: IPConnectionSettings) -> None:
         super().__init__()


### PR DESCRIPTION
Fixes #35 

This PR adds a top-level writing attribute, and adjusts how `StatusSummaryUpdater` handles its base case. Typing was also amended to allow a `tuple` of multiple `str` without linting errors.