### PR TITLE
Log path and value in metadata validation error

### DIFF
--- a/src/fastcs_odin/__main__.py
+++ b/src/fastcs_odin/__main__.py
@@ -41,7 +41,7 @@ def main(
     pass
 
 
-OdinIp = typer.Option("172.23.104.227", help="IP address of odin server")
+OdinIp = typer.Option("127.0.0.1", help="IP address of odin server")
 OdinPort = typer.Option(8888, help="Port of odin server")
 
 

--- a/src/fastcs_odin/__main__.py
+++ b/src/fastcs_odin/__main__.py
@@ -41,7 +41,7 @@ def main(
     pass
 
 
-OdinIp = typer.Option("127.0.0.1", help="IP address of odin server")
+OdinIp = typer.Option("172.23.104.227", help="IP address of odin server")
 OdinPort = typer.Option(8888, help="Port of odin server")
 
 

--- a/src/fastcs_odin/util.py
+++ b/src/fastcs_odin/util.py
@@ -130,7 +130,10 @@ def _walk_odin_metadata(
                     # TODO: This won't be needed when all parameters provide metadata
                     yield (node_path, infer_metadata(node_value, node_path))
             except ValidationError as e:
-                logging.warning(f"Type not supported:\n{e}")
+                logging.warning(
+                    f"Type not supported for path {node_path} "
+                    f"with value {node_value}:\n{e}"
+                )
 
 
 def infer_metadata(parameter: Any, uri: list[str]):


### PR DESCRIPTION
Related to #68.

This PR adds more information to the metadata validation error. This used to be:
```bash
WARNING:root:Type not supported:
1 validation error for OdinParameterMetadata
type
  Input should be 'float', 'int', 'bool' or 'str' [type=literal_error, input_value='list', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/literal_error
```

and is now:
```
WARNING:root:Type not supported for path ['0', 'command', 'hdf', 'allowed'] with value {'value': ['start_writing', 'stop_writing'], 'writeable': False, 'type': 'list'}:
1 validation error for OdinParameterMetadata
type
  Input should be 'float', 'int', 'bool' or 'str' [type=literal_error, input_value='list', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/literal_error
```