### PR TITLE
Split StatusSummaryUpdater attribute filtering

### DIFF
--- a/src/fastcs_odin/__main__.py
+++ b/src/fastcs_odin/__main__.py
@@ -41,7 +41,7 @@ def main(
     pass
 
 
-OdinIp = typer.Option("172.23.104.227", help="IP address of odin server")
+OdinIp = typer.Option("127.0.0.1", help="IP address of odin server")
 OdinPort = typer.Option(8888, help="Port of odin server")
 
 

--- a/src/fastcs_odin/__main__.py
+++ b/src/fastcs_odin/__main__.py
@@ -41,7 +41,7 @@ def main(
     pass
 
 
-OdinIp = typer.Option("127.0.0.1", help="IP address of odin server")
+OdinIp = typer.Option("172.23.104.227", help="IP address of odin server")
 OdinPort = typer.Option(8888, help="Port of odin server")
 
 

--- a/src/fastcs_odin/frame_processor.py
+++ b/src/fastcs_odin/frame_processor.py
@@ -1,5 +1,6 @@
 import re
 from collections.abc import Sequence
+from functools import partial
 
 from fastcs.attributes import AttrR
 from fastcs.datatypes import Bool, Int
@@ -56,7 +57,9 @@ class FrameProcessorController(OdinDataController):
 class FrameProcessorAdapterController(OdinDataAdapterController):
     frames_written: AttrR = AttrR(
         Int(),
-        handler=StatusSummaryUpdater([re.compile("FP*"), "HDF"], "frames_written", sum),  # type: ignore
+        handler=StatusSummaryUpdater(
+            [re.compile("FP*"), "HDF"], "frames_written", partial(sum, start=0)
+        ),
     )
     writing: AttrR = AttrR(
         Bool(),

--- a/src/fastcs_odin/frame_processor.py
+++ b/src/fastcs_odin/frame_processor.py
@@ -56,7 +56,7 @@ class FrameProcessorController(OdinDataController):
 class FrameProcessorAdapterController(OdinDataAdapterController):
     frames_written: AttrR = AttrR(
         Int(),
-        handler=StatusSummaryUpdater([re.compile("FP*"), "HDF"], "frames_written", sum),
+        handler=StatusSummaryUpdater([re.compile("FP*"), "HDF"], "frames_written", sum),  # type: ignore
     )
     writing: AttrR = AttrR(
         Bool(),

--- a/src/fastcs_odin/odin_adapter_controller.py
+++ b/src/fastcs_odin/odin_adapter_controller.py
@@ -105,7 +105,7 @@ class StatusSummaryUpdater(AttrHandlerR, Generic[In, Out]):
             if isinstance(attr := sub_controller.attributes[self.attribute_name], AttrR)
         ]
 
-    async def update(self, attr: AttrR):  # type: ignore
+    async def update(self, attr: AttrR):
         values = [attribute.get() for attribute in self.attributes]
         await attr.set(self.accumulator(values))
 

--- a/src/fastcs_odin/odin_adapter_controller.py
+++ b/src/fastcs_odin/odin_adapter_controller.py
@@ -105,7 +105,7 @@ class StatusSummaryUpdater(AttrHandlerR, Generic[In, Out]):
             if isinstance(attr := sub_controller.attributes[self.attribute_name], AttrR)
         ]
 
-    async def update(self, attr: AttrR[Out]):
+    async def update(self, attr: AttrR[Out]):  # type: ignore
         values = [attribute.get() for attribute in self.attributes]
         await attr.set(self.accumulator(values))
 

--- a/src/fastcs_odin/odin_adapter_controller.py
+++ b/src/fastcs_odin/odin_adapter_controller.py
@@ -105,7 +105,7 @@ class StatusSummaryUpdater(AttrHandlerR, Generic[In, Out]):
             if isinstance(attr := sub_controller.attributes[self.attribute_name], AttrR)
         ]
 
-    async def update(self, attr: AttrR[Out]):  # type: ignore
+    async def update(self, attr: AttrR):  # type: ignore
         values = [attribute.get() for attribute in self.attributes]
         await attr.set(self.accumulator(values))
 

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -327,7 +327,7 @@ async def test_status_summary_updater(mocker: MockerFixture):
     handler = StatusSummaryUpdater(
         ["OD", ("FP",), re.compile("FP*"), "HDF"],
         "frames_written",
-        sum,
+        sum,  # type: ignore
     )
 
     await handler.initialise(controller)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -1,4 +1,5 @@
 import re
+from functools import partial
 from pathlib import Path
 
 import pytest
@@ -327,7 +328,7 @@ async def test_status_summary_updater(mocker: MockerFixture):
     handler = StatusSummaryUpdater(
         ["OD", ("FP",), re.compile("FP*"), "HDF"],
         "frames_written",
-        sum,  # type: ignore
+        partial(sum, start=0),
     )
 
     await handler.initialise(controller)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -327,7 +327,7 @@ async def test_status_summary_updater(mocker: MockerFixture):
     handler = StatusSummaryUpdater(
         ["OD", ("FP",), re.compile("FP*"), "HDF"],
         "frames_written",
-        sum,  # type: ignore
+        sum,
     )
 
     await handler.initialise(controller)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -318,11 +318,18 @@ async def test_status_summary_updater(mocker: MockerFixture):
     }
     fpx_controller.get_sub_controllers.return_value = {"HDF": hdf_controller}
 
-    hdf_controller.attributes["frames_written"].get.return_value = 50
+    hdf_controller.attributes = {}
+
+    mock_frames_written = mocker.create_autospec(AttrR)
+    mock_frames_written.get.return_value = 50
+    hdf_controller.attributes["frames_written"] = mock_frames_written
 
     handler = StatusSummaryUpdater(
-        ["OD", ("FP",), re.compile("FP*"), "HDF"], "frames_written", sum
+        ["OD", ("FP",), re.compile("FP*"), "HDF"],
+        "frames_written",
+        sum,  # type: ignore
     )
+
     await handler.initialise(controller)
     await handler.update(attr)
     attr.set.assert_called_once_with(100)
@@ -331,7 +338,10 @@ async def test_status_summary_updater(mocker: MockerFixture):
         ["OD", ("FP",), re.compile("FP*"), ("HDF",)], "writing", any
     )
 
-    hdf_controller.attributes["writing"].get.side_effect = [True, False]
+    mock_writing = mocker.create_autospec(AttrR)
+    mock_writing.get.side_effect = [True, False]
+    hdf_controller.attributes["writing"] = mock_writing
+
     await handler.initialise(controller)
     await handler.update(attr)
     attr.set.assert_called_with(True)
@@ -348,14 +358,11 @@ async def test_status_summary_updater_raise_exception(
     mock_sub_controller, mocker: MockerFixture
 ):
     controller = mocker.MagicMock()
-    attr = mocker.AsyncMock()
     controller.get_sub_controllers.return_value = {"OD": mocker.MagicMock()}
 
     handler = StatusSummaryUpdater(["OD", mock_sub_controller], "writing", any)
-    await handler.initialise(controller)
-
     with pytest.raises(ValueError, match="not found"):
-        await handler.update(attr)
+        await handler.initialise(controller)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #21

This PR populates `StatusSummaryUpdater` attributes in `initialise`, such that `update` just uses a list of attributes. This PR also amends typing based on https://github.com/DiamondLightSource/fastcs-odin/issues/21#issuecomment-2531108415