### PR TITLE
Hint data attributes on fp adapter

### DIFF
--- a/src/fastcs_odin/controllers/odin_data/frame_processor.py
+++ b/src/fastcs_odin/controllers/odin_data/frame_processor.py
@@ -79,6 +79,10 @@ class FrameProcessorAdapterController(OdinDataAdapterController):
     process_frames_per_block: AttrRW[int]
     process_blocks_per_file: AttrRW[int]
     frames: AttrR[int]
+    data_compression: AttrRW[str]
+    data_datatype: AttrRW[str]
+    data_dims_0: AttrR[int]  # y
+    data_dims_1: AttrR[int]  # x
 
     frames_written = AttrR(
         Int(),


### PR DESCRIPTION
This adds type hints for the following attributes into `FrameProcessorAdapterController`:

```python
    data_compression: AttrRW[str]
    data_datatype: AttrRW[str]
    data_dims_0: AttrR[int]  # y
    data_dims_1: AttrR[int]  # x
``` 

This is defined in `EigerFrameProcessorAdapterController` on `fastcs_eiger`, but `fastcs-jungfrau` needs these attributes too, so we should redefine it here.