### PR TITLE
Move VDS generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,18 +12,15 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 description = "FastCS support for the Odin detector software framework"
-dependencies = [
-    "aiohttp",
-    "fastcs[epicsca]~=0.12.0",
-]
+dependencies = ["aiohttp", "fastcs[epicsca]~=0.12.0", "h5py"]
 dynamic = ["version"]
 license.file = "LICENSE"
 readme = "README.md"
 requires-python = ">=3.11"
 
 authors = [
-    {name = "James Souter", email = "james.souter@diamond.ac.uk"},
-    {name = "Gary Yendell", email = "gary.yendell@diamond.ac.uk"},
+    { name = "James Souter", email = "james.souter@diamond.ac.uk" },
+    { name = "Gary Yendell", email = "gary.yendell@diamond.ac.uk" },
 ]
 
 [dependency-groups]
@@ -63,7 +60,7 @@ version_file = "src/fastcs_odin/_version.py"
 
 [tool.pyright]
 typeCheckingMode = "standard"
-reportMissingImports = false # Ignore missing stubs in imported modules
+reportMissingImports = false  # Ignore missing stubs in imported modules
 
 [tool.pytest.ini_options]
 # Run pytest with all our checkers, and don't spam us with massive tracebacks on error

--- a/src/fastcs_odin/controllers/odin_data/_generate_vds.py
+++ b/src/fastcs_odin/controllers/odin_data/_generate_vds.py
@@ -1,0 +1,119 @@
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+import h5py
+from fastcs.logging import logger
+
+
+@dataclass
+class FileFrames:
+    frames: int
+    start: int
+    frames_per_block: int
+
+    @property
+    def blocks(self):
+        return self.frames // self.frames_per_block
+
+    @property
+    def remainder_frames(self):
+        return self.frames % self.frames_per_block
+
+
+def _get_frames_per_file_writer(
+    frame_count: int, frames_per_block: int, n_file_writers: int
+) -> list[int]:
+    n_blocks = math.ceil(frame_count / frames_per_block)
+    min_blocks_per_file = n_blocks // n_file_writers
+    remainder = n_blocks - min_blocks_per_file * n_file_writers
+
+    frames_per_file_writer = []
+    for i in range(n_file_writers):
+        blocks = min_blocks_per_file + (i < remainder)
+        frames_per_file_writer.append(blocks * frames_per_block)
+
+    overflow = sum(frames_per_file_writer) - frame_count
+    frames_per_file_writer[remainder - 1] -= overflow
+    return frames_per_file_writer
+
+
+def _calculate_frame_distribution(
+    frame_count, frames_per_block, blocks_per_file, n_file_writers
+) -> dict[int, FileFrames]:
+    frame_distribution: dict[int, FileFrames] = {}
+
+    max_frames_per_file = (
+        frames_per_block * blocks_per_file if blocks_per_file else frame_count
+    )
+    # total frames written before one of the file writers has to start a new file
+    frames_before_new_file = n_file_writers * max_frames_per_file
+    frames_per_file_writer = _get_frames_per_file_writer(
+        frame_count, frames_per_block, n_file_writers
+    )
+    for file_writer_idx, n_frames in enumerate(frames_per_file_writer):
+        n_files = math.ceil(n_frames / max_frames_per_file)
+        for i in range(n_files):
+            file_idx = file_writer_idx + i * n_file_writers
+
+            frame_distribution[file_idx + 1] = FileFrames(
+                frames=min(n_frames - i * max_frames_per_file, max_frames_per_file),
+                frames_per_block=frames_per_block,
+                start=frames_per_block * file_writer_idx
+                + file_idx // n_file_writers * frames_before_new_file,
+            )
+
+    return frame_distribution
+
+
+def create_interleave_vds(
+    path: Path,
+    prefix: str,
+    datasets: list[str],
+    frame_count: int,
+    frames_per_block: int,
+    blocks_per_file: int,
+    frame_shape: tuple[int, int],
+    dtype: str = "float",
+    n_file_writers: int = 4,
+) -> None:
+    frame_distribution = _calculate_frame_distribution(
+        frame_count, frames_per_block, blocks_per_file, n_file_writers
+    )
+    stride = n_file_writers * frames_per_block
+    filepath = f"{path / prefix}_vds.h5"
+    logger.info(f"Writing virtual dataset at {filepath}")
+    with h5py.File(f"{path / prefix}_vds.h5", "w", libver="latest") as f:
+        for dataset_name in datasets:
+            v_layout = h5py.VirtualLayout(
+                shape=(frame_count, frame_shape[0], frame_shape[1]),
+                dtype=dtype,
+            )
+            for file_number, file_frames in frame_distribution.items():
+                full_block_frames = file_frames.blocks * frames_per_block
+                v_source = h5py.VirtualSource(
+                    f"{prefix}_{str(file_number).zfill(6)}.h5",
+                    name=dataset_name,
+                    shape=(file_frames.frames, frame_shape[0], frame_shape[1]),
+                    dtype=dtype,
+                )
+                if file_frames.blocks:
+                    source = v_source[:full_block_frames, :, :]
+                    v_layout[
+                        h5py.MultiBlockSlice(
+                            start=file_frames.start,
+                            stride=stride,
+                            count=file_frames.blocks,
+                            block=frames_per_block,
+                        ),
+                        :,
+                        :,
+                    ] = source
+                if file_frames.remainder_frames:
+                    # Last few frames that don't fit into a block
+                    source = v_source[full_block_frames : file_frames.frames, :, :]
+                    v_layout[
+                        frame_count - file_frames.remainder_frames : frame_count, :, :
+                    ] = source
+
+            f.create_virtual_dataset(dataset_name, v_layout)

--- a/src/fastcs_odin/controllers/odin_data/_generate_vds.py
+++ b/src/fastcs_odin/controllers/odin_data/_generate_vds.py
@@ -21,99 +21,105 @@ class FileFrames:
         return self.frames % self.frames_per_block
 
 
-def _get_frames_per_file_writer(
-    frame_count: int, frames_per_block: int, n_file_writers: int
-) -> list[int]:
-    n_blocks = math.ceil(frame_count / frames_per_block)
-    min_blocks_per_file = n_blocks // n_file_writers
-    remainder = n_blocks - min_blocks_per_file * n_file_writers
+class VDSGenerator:
+    def __init__(self, path: Path, prefix: str):
+        self.path = path
+        self.prefix = prefix
 
-    frames_per_file_writer = []
-    for i in range(n_file_writers):
-        blocks = min_blocks_per_file + (i < remainder)
-        frames_per_file_writer.append(blocks * frames_per_block)
+    @staticmethod
+    def _get_frames_per_file_writer(
+        frame_count: int, frames_per_block: int, n_file_writers: int
+    ) -> list[int]:
+        n_blocks = math.ceil(frame_count / frames_per_block)
+        min_blocks_per_file = n_blocks // n_file_writers
+        remainder = n_blocks - min_blocks_per_file * n_file_writers
 
-    overflow = sum(frames_per_file_writer) - frame_count
-    frames_per_file_writer[remainder - 1] -= overflow
-    return frames_per_file_writer
+        frames_per_file_writer = []
+        for i in range(n_file_writers):
+            blocks = min_blocks_per_file + (i < remainder)
+            frames_per_file_writer.append(blocks * frames_per_block)
 
+        overflow = sum(frames_per_file_writer) - frame_count
+        frames_per_file_writer[remainder - 1] -= overflow
+        return frames_per_file_writer
 
-def _calculate_frame_distribution(
-    frame_count, frames_per_block, blocks_per_file, n_file_writers
-) -> dict[int, FileFrames]:
-    frame_distribution: dict[int, FileFrames] = {}
-
-    max_frames_per_file = (
-        frames_per_block * blocks_per_file if blocks_per_file else frame_count
-    )
-    # total frames written before one of the file writers has to start a new file
-    frames_before_new_file = n_file_writers * max_frames_per_file
-    frames_per_file_writer = _get_frames_per_file_writer(
-        frame_count, frames_per_block, n_file_writers
-    )
-    for file_writer_idx, n_frames in enumerate(frames_per_file_writer):
-        n_files = math.ceil(n_frames / max_frames_per_file)
-        for i in range(n_files):
-            file_idx = file_writer_idx + i * n_file_writers
-
-            frame_distribution[file_idx + 1] = FileFrames(
-                frames=min(n_frames - i * max_frames_per_file, max_frames_per_file),
-                frames_per_block=frames_per_block,
-                start=frames_per_block * file_writer_idx
-                + file_idx // n_file_writers * frames_before_new_file,
-            )
-
-    return frame_distribution
-
-
-def create_interleave_vds(
-    path: Path,
-    prefix: str,
-    datasets: list[str],
-    frame_count: int,
-    frames_per_block: int,
-    blocks_per_file: int,
-    frame_shape: tuple[int, int],
-    dtype: str = "float",
-    n_file_writers: int = 4,
-) -> None:
-    frame_distribution = _calculate_frame_distribution(
+    @staticmethod
+    def _calculate_frame_distribution(
         frame_count, frames_per_block, blocks_per_file, n_file_writers
-    )
-    stride = n_file_writers * frames_per_block
-    filepath = f"{path / prefix}_vds.h5"
-    logger.info(f"Writing virtual dataset at {filepath}")
-    with h5py.File(f"{path / prefix}_vds.h5", "w", libver="latest") as f:
-        for dataset_name in datasets:
-            v_layout = h5py.VirtualLayout(
-                shape=(frame_count, frame_shape[0], frame_shape[1]),
-                dtype=dtype,
-            )
-            for file_number, file_frames in frame_distribution.items():
-                full_block_frames = file_frames.blocks * frames_per_block
-                v_source = h5py.VirtualSource(
-                    f"{prefix}_{str(file_number).zfill(6)}.h5",
-                    name=dataset_name,
-                    shape=(file_frames.frames, frame_shape[0], frame_shape[1]),
+    ) -> dict[int, FileFrames]:
+        frame_distribution: dict[int, FileFrames] = {}
+
+        max_frames_per_file = (
+            frames_per_block * blocks_per_file if blocks_per_file else frame_count
+        )
+        # total frames written before one of the file writers has to start a new file
+        frames_before_new_file = n_file_writers * max_frames_per_file
+        frames_per_file_writer = VDSGenerator._get_frames_per_file_writer(
+            frame_count, frames_per_block, n_file_writers
+        )
+        for file_writer_idx, n_frames in enumerate(frames_per_file_writer):
+            n_files = math.ceil(n_frames / max_frames_per_file)
+            for i in range(n_files):
+                file_idx = file_writer_idx + i * n_file_writers
+
+                frame_distribution[file_idx + 1] = FileFrames(
+                    frames=min(n_frames - i * max_frames_per_file, max_frames_per_file),
+                    frames_per_block=frames_per_block,
+                    start=frames_per_block * file_writer_idx
+                    + file_idx // n_file_writers * frames_before_new_file,
+                )
+
+        return frame_distribution
+
+    def create_interleave_vds(
+        self,
+        datasets: list[str],
+        frame_count: int,
+        frames_per_block: int,
+        blocks_per_file: int,
+        frame_shape: tuple[int, int],
+        dtype: str = "float",
+        n_file_writers: int = 4,
+    ) -> None:
+        frame_distribution = self._calculate_frame_distribution(
+            frame_count, frames_per_block, blocks_per_file, n_file_writers
+        )
+        stride = n_file_writers * frames_per_block
+        filepath = f"{self.path / self.prefix}_vds.h5"
+        logger.info(f"Writing virtual dataset at {filepath}")
+        with h5py.File(f"{self.path / self.prefix}_vds.h5", "w", libver="latest") as f:
+            for dataset_name in datasets:
+                v_layout = h5py.VirtualLayout(
+                    shape=(frame_count, frame_shape[0], frame_shape[1]),
                     dtype=dtype,
                 )
-                if file_frames.blocks:
-                    source = v_source[:full_block_frames, :, :]
-                    v_layout[
-                        h5py.MultiBlockSlice(
-                            start=file_frames.start,
-                            stride=stride,
-                            count=file_frames.blocks,
-                            block=frames_per_block,
-                        ),
-                        :,
-                        :,
-                    ] = source
-                if file_frames.remainder_frames:
-                    # Last few frames that don't fit into a block
-                    source = v_source[full_block_frames : file_frames.frames, :, :]
-                    v_layout[
-                        frame_count - file_frames.remainder_frames : frame_count, :, :
-                    ] = source
+                for file_number, file_frames in frame_distribution.items():
+                    full_block_frames = file_frames.blocks * frames_per_block
+                    v_source = h5py.VirtualSource(
+                        f"{self.prefix}_{str(file_number).zfill(6)}.h5",
+                        name=dataset_name,
+                        shape=(file_frames.frames, frame_shape[0], frame_shape[1]),
+                        dtype=dtype,
+                    )
+                    if file_frames.blocks:
+                        source = v_source[:full_block_frames, :, :]
+                        v_layout[
+                            h5py.MultiBlockSlice(
+                                start=file_frames.start,
+                                stride=stride,
+                                count=file_frames.blocks,
+                                block=frames_per_block,
+                            ),
+                            :,
+                            :,
+                        ] = source
+                    if file_frames.remainder_frames:
+                        # Last few frames that don't fit into a block
+                        source = v_source[full_block_frames : file_frames.frames, :, :]
+                        v_layout[
+                            frame_count - file_frames.remainder_frames : frame_count,
+                            :,
+                            :,
+                        ] = source
 
-            f.create_virtual_dataset(dataset_name, v_layout)
+                f.create_virtual_dataset(dataset_name, v_layout)

--- a/src/fastcs_odin/controllers/odin_data/frame_processor.py
+++ b/src/fastcs_odin/controllers/odin_data/frame_processor.py
@@ -8,7 +8,7 @@ from fastcs.attributes import AttrR, AttrRW
 from fastcs.datatypes import Bool, Int
 from fastcs.methods import command
 
-from fastcs_odin.controllers.odin_data._generate_vds import create_interleave_vds
+from fastcs_odin.controllers.odin_data._generate_vds import VDSGenerator
 from fastcs_odin.controllers.odin_data.odin_data_adapter import (
     OdinDataAdapterController,
 )
@@ -137,28 +137,35 @@ class FrameProcessorAdapterController(OdinDataAdapterController):
     def _stop_writing_commands(self):
         return self._collect_commands((re.compile(r"[0-9]+"), "HDF"), "stop_writing")
 
-    @command()
-    async def start_writing(self) -> None:
+    def _create_vds(self):
         if self.enable_vds_creation.get():
-            create_interleave_vds(
-                path=Path(self.file_path.get()),
-                prefix=self.file_prefix.get(),
+            self.vds.create_interleave_vds(
                 datasets=["data", "data2", "data3"],
-                frame_count=self.frames.get(),
+                frame_count=self.frames_written.get(),
                 frames_per_block=self.process_frames_per_block.get(),
                 blocks_per_file=self.process_blocks_per_file.get(),
                 frame_shape=(
-                    self.data_dims_1.get(),
                     self.data_dims_0.get(),
+                    self.data_dims_1.get(),
                 ),
                 dtype=self.data_datatype.get(),
             )
-            await asyncio.gather(
-                *(start_writing() for start_writing in self._start_writing_commands)
-            )
+
+    def _instantiate_vds_generator(self):
+        self.vds = VDSGenerator(
+            path=Path(self.file_path.get()), prefix=self.file_prefix.get()
+        )
+
+    @command()
+    async def start_writing(self) -> None:
+        self._instantiate_vds_generator()
+        await asyncio.gather(
+            *(start_writing() for start_writing in self._start_writing_commands)
+        )
 
     @command()
     async def stop_writing(self) -> None:
+        self._create_vds()
         await asyncio.gather(
             *(stop_writing() for stop_writing in self._stop_writing_commands)
         )

--- a/src/fastcs_odin/controllers/odin_data/frame_processor.py
+++ b/src/fastcs_odin/controllers/odin_data/frame_processor.py
@@ -2,11 +2,13 @@ import asyncio
 import re
 from collections.abc import Sequence
 from functools import cached_property, partial
+from pathlib import Path
 
 from fastcs.attributes import AttrR, AttrRW
 from fastcs.datatypes import Bool, Int
 from fastcs.methods import command
 
+from fastcs_odin.controllers.odin_data._generate_vds import create_interleave_vds
 from fastcs_odin.controllers.odin_data.odin_data_adapter import (
     OdinDataAdapterController,
 )
@@ -79,6 +81,9 @@ class FrameProcessorAdapterController(OdinDataAdapterController):
     process_frames_per_block: AttrRW[int]
     process_blocks_per_file: AttrRW[int]
     frames: AttrR[int]
+    data_datatype: AttrRW[str]
+    data_dims_0: AttrR[int]  # y
+    data_dims_1: AttrR[int]  # x
     enable_vds_creation = AttrRW(Bool())
 
     frames_written = AttrR(
@@ -134,9 +139,23 @@ class FrameProcessorAdapterController(OdinDataAdapterController):
 
     @command()
     async def start_writing(self) -> None:
-        await asyncio.gather(
-            *(start_writing() for start_writing in self._start_writing_commands)
-        )
+        if self.enable_vds_creation.get():
+            create_interleave_vds(
+                path=Path(self.file_path.get()),
+                prefix=self.file_prefix.get(),
+                datasets=["data", "data2", "data3"],
+                frame_count=self.frames.get(),
+                frames_per_block=self.process_frames_per_block.get(),
+                blocks_per_file=self.process_blocks_per_file.get(),
+                frame_shape=(
+                    self.data_dims_1.get(),
+                    self.data_dims_0.get(),
+                ),
+                dtype=self.data_datatype.get(),
+            )
+            await asyncio.gather(
+                *(start_writing() for start_writing in self._start_writing_commands)
+            )
 
     @command()
     async def stop_writing(self) -> None:

--- a/src/fastcs_odin/controllers/odin_data/frame_processor.py
+++ b/src/fastcs_odin/controllers/odin_data/frame_processor.py
@@ -79,6 +79,7 @@ class FrameProcessorAdapterController(OdinDataAdapterController):
     process_frames_per_block: AttrRW[int]
     process_blocks_per_file: AttrRW[int]
     frames: AttrR[int]
+    enable_vds_creation = AttrRW(Bool())
 
     frames_written = AttrR(
         Int(),

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -2,12 +2,13 @@ import json
 import re
 from functools import partial
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from fastcs.attributes import AttrR, AttrRW
 from fastcs.connections import IPConnectionSettings
 from fastcs.controllers import Controller
-from fastcs.datatypes import Bool, Float, Int
+from fastcs.datatypes import Bool, Float, Int, String
 from pytest_mock import MockerFixture
 
 from fastcs_odin.controllers.odin_adapter_controller import OdinAdapterController
@@ -498,6 +499,9 @@ async def test_frame_processor_start_and_stop_writing(mocker: MockerFixture):
     hdf.start_writing = mocker.AsyncMock()  # type: ignore
     hdf.stop_writing = mocker.AsyncMock()  # type: ignore
 
+    fpac.file_path = AttrRW(String())
+    fpac.file_prefix = AttrRW(String())
+
     fpac[0] = fpc
 
     # Top level FP commands should collect and call lower level commands
@@ -505,6 +509,69 @@ async def test_frame_processor_start_and_stop_writing(mocker: MockerFixture):
     await fpac.stop_writing()
     assert len(hdf.start_writing.mock_calls) == 1  # type: ignore
     assert len(hdf.stop_writing.mock_calls) == 1  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_vds_generator_created_on_start_writing(mocker: MockerFixture):
+    fpac = FrameProcessorAdapterController(
+        mocker.AsyncMock(), mocker.AsyncMock(), "api/0.1", []
+    )
+    fpc = FrameProcessorController(
+        mocker.AsyncMock(), mocker.AsyncMock(), "api/0.1", []
+    )
+    await fpc._create_plugin_sub_controllers(["hdf"])
+
+    hdf = fpc.sub_controllers["HDF"]
+    hdf.start_writing = mocker.AsyncMock()
+    hdf.stop_writing = mocker.AsyncMock()
+
+    fpac.file_path = AttrRW(String(), initial_value="test_path")
+    fpac.file_prefix = AttrRW(String(), initial_value="test_prefix")
+
+    fpac[0] = fpc
+
+    await fpac.start_writing()
+    assert fpac.vds.path == Path("test_path")
+    assert fpac.vds.prefix == "test_prefix"
+
+
+@pytest.mark.asyncio
+async def test_vds_created_on_stop_writing_if_vds_enabled(mocker: MockerFixture):
+    fpac = FrameProcessorAdapterController(
+        mocker.AsyncMock(), mocker.AsyncMock(), "api/0.1", []
+    )
+    fpc = FrameProcessorController(
+        mocker.AsyncMock(), mocker.AsyncMock(), "api/0.1", []
+    )
+    await fpc._create_plugin_sub_controllers(["hdf"])
+
+    hdf = fpc.sub_controllers["HDF"]
+    hdf.start_writing = mocker.AsyncMock()
+    hdf.stop_writing = mocker.AsyncMock()
+
+    await fpac.enable_vds_creation.put(True)
+    fpac.file_path = AttrRW(String(), initial_value="test_path")
+    fpac.file_prefix = AttrRW(String(), initial_value="test_prefix")
+    fpac.process_frames_per_block = AttrRW(Int(), initial_value=1)
+    fpac.process_blocks_per_file = AttrRW(Int(), initial_value=0)
+    fpac.data_dims_0 = AttrRW(Int(), initial_value=10)
+    fpac.data_dims_1 = AttrRW(Int(), initial_value=20)
+    fpac.data_datatype = AttrRW(String(), initial_value="uint32")
+    fpac.frames_written.get = MagicMock(return_value=100)
+
+    fpac[0] = fpc
+
+    await fpac.start_writing()
+    fpac.vds.create_interleave_vds = MagicMock()
+    await fpac.stop_writing()
+    fpac.vds.create_interleave_vds.assert_called_once_with(
+        datasets=["data", "data2", "data3"],
+        frame_count=100,
+        frames_per_block=1,
+        blocks_per_file=0,
+        frame_shape=(10, 20),
+        dtype="uint32",
+    )
 
 
 @pytest.mark.asyncio
@@ -520,6 +587,9 @@ async def test_top_level_frame_processor_commands_raise_exception(
     )
     await fpc._create_plugin_sub_controllers(["hdf"])
     fpac[0] = fpc
+
+    fpac.file_path = AttrRW(String(), initial_value="")
+    fpac.file_prefix = AttrRW(String(), initial_value="")
 
     with pytest.raises(AttributeError, match="does not have"):
         await fpac.start_writing()

--- a/tests/test_generate_vds.py
+++ b/tests/test_generate_vds.py
@@ -5,12 +5,7 @@ import h5py
 import numpy as np
 import pytest
 
-from fastcs_odin.controllers.odin_data._generate_vds import (
-    FileFrames,
-    _calculate_frame_distribution,
-    _get_frames_per_file_writer,
-    create_interleave_vds,
-)
+from fastcs_odin.controllers.odin_data._generate_vds import FileFrames, VDSGenerator
 
 
 @pytest.mark.parametrize(
@@ -33,7 +28,7 @@ def test_get_frames_per_file_writer_splits_frames_correctly(
     n_file_writers: int,
     expected_split_frames: list[int],
 ):
-    split_frames_numbers = _get_frames_per_file_writer(
+    split_frames_numbers = VDSGenerator._get_frames_per_file_writer(
         frame_count, frames_per_block, n_file_writers
     )
     assert split_frames_numbers == expected_split_frames
@@ -87,9 +82,8 @@ def test_create_interleave_vds_layout_contains_expected_files_and_has_expected_s
         "fastcs_odin.controllers.odin_data._generate_vds.h5py.File",
         return_value=mock_file,
     ):
-        create_interleave_vds(
-            Path(),
-            "test",
+        vds = VDSGenerator(Path(), "test")
+        vds.create_interleave_vds(
             ["data"],
             frame_count,
             frames_per_block,
@@ -125,9 +119,8 @@ def test_create_interleave_cds_makes_expected_source_layout_calls(
     expected_frames_per_file: list[int],
 ):
     datasets = ["data", "sets"]
-    create_interleave_vds(
-        Path(),
-        "test",
+    vds = VDSGenerator(Path(), "test")
+    vds.create_interleave_vds(
         datasets,
         frame_count,
         frames_per_block,
@@ -208,7 +201,7 @@ def test_calculate_frame_distribution(
     n_writers: int,
     expected_distribution: dict[int, FileFrames],
 ):
-    result = _calculate_frame_distribution(
+    result = VDSGenerator._calculate_frame_distribution(
         frame_count, frames_per_block, blocks_per_file, n_writers
     )
     assert result == expected_distribution
@@ -303,7 +296,8 @@ def test_create_interleave_vds_before_files_written(
     acquired_data, expected_vds_data = mock_round_robin_data
     prefix = "test"
 
-    create_interleave_vds(tmp_path, prefix, ["data"], 19, 2, 2, (2, 2))
+    vds = VDSGenerator(tmp_path, prefix)
+    vds.create_interleave_vds(["data"], 19, 2, 2, (2, 2))
 
     for i, data in enumerate(acquired_data):
         with h5py.File(tmp_path / f"test_00000{i + 1}.h5", "w") as f:
@@ -328,7 +322,8 @@ def test_create_interleave_vds_after_files_written(
         with h5py.File(tmp_path / f"test_00000{i + 1}.h5", "w") as f:
             f.create_dataset(name="data", data=data)
 
-    create_interleave_vds(tmp_path, prefix, ["data"], 19, 2, 2, (2, 2))
+    vds = VDSGenerator(tmp_path, prefix)
+    vds.create_interleave_vds(["data"], 19, 2, 2, (2, 2))
 
     with h5py.File(f"{tmp_path / prefix}_vds.h5", "r") as f:
         virtual_dataset = f.get("data")
@@ -351,7 +346,8 @@ def test_create_interleave_vds_creates_virtual_dataset_for_all_datasets(
             f.create_dataset(name="two", data=data * 10)
             f.create_dataset(name="three", data=data * 100)
 
-    create_interleave_vds(tmp_path, prefix, ["one", "two", "three"], 19, 2, 2, (2, 2))
+    vds = VDSGenerator(tmp_path, prefix)
+    vds.create_interleave_vds(["one", "two", "three"], 19, 2, 2, (2, 2))
 
     with h5py.File(f"{tmp_path / prefix}_vds.h5", "r") as f:
         assert np.array_equal(f.get("one")[()], np.zeros(expected_vds_data.shape))  # type: ignore

--- a/tests/test_generate_vds.py
+++ b/tests/test_generate_vds.py
@@ -1,0 +1,359 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import h5py
+import numpy as np
+import pytest
+
+from fastcs_odin.controllers.odin_data._generate_vds import (
+    FileFrames,
+    _calculate_frame_distribution,
+    _get_frames_per_file_writer,
+    create_interleave_vds,
+)
+
+
+@pytest.mark.parametrize(
+    "frame_count, frames_per_block, n_file_writers, expected_split_frames",
+    [
+        [10, 1, 3, [4, 3, 3]],
+        [10, 1, 10, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]],
+        [10, 4, 10, [4, 4, 2, 0, 0, 0, 0, 0, 0, 0]],
+        [10, 1, 1, [10]],
+        [10, 4, 2, [6, 4]],
+        [10, 4, 3, [4, 4, 2]],
+        [10, 3, 3, [4, 3, 3]],
+        [105, 10, 4, [30, 30, 25, 20]],
+        [1000000, 500, 4, [250000, 250000, 250000, 250000]],
+    ],
+)
+def test_get_frames_per_file_writer_splits_frames_correctly(
+    frame_count: int,
+    frames_per_block: int,
+    n_file_writers: int,
+    expected_split_frames: list[int],
+):
+    split_frames_numbers = _get_frames_per_file_writer(
+        frame_count, frames_per_block, n_file_writers
+    )
+    assert split_frames_numbers == expected_split_frames
+
+
+@pytest.mark.parametrize(
+    "frame_count, frames_per_block, blocks_per_file, n_file_writers, expected_files",
+    [
+        [100, 10, 5, 1, {b"test_000001.h5", b"test_000002.h5"}],
+        [105, 10, 5, 1, {b"test_000001.h5", b"test_000002.h5", b"test_000003.h5"}],
+        [
+            25,
+            5,
+            1,
+            4,
+            {
+                b"test_000001.h5",
+                b"test_000002.h5",
+                b"test_000003.h5",
+                b"test_000004.h5",
+                b"test_000005.h5",
+            },
+        ],
+        [105, 10, 0, 1, {b"test_000001.h5"}],
+        [1000, 2, 0, 2, {b"test_000001.h5", b"test_000002.h5"}],
+        [
+            100,
+            10,
+            3,
+            2,
+            {
+                b"test_000001.h5",
+                b"test_000002.h5",
+                b"test_000003.h5",
+                b"test_000004.h5",
+            },
+        ],
+    ],
+)
+def test_create_interleave_vds_layout_contains_expected_files_and_has_expected_shape(
+    frame_count: int,
+    frames_per_block: int,
+    blocks_per_file: int,
+    n_file_writers: int,
+    expected_files: set[str],
+):
+    mock_file = MagicMock()
+    mock_f = MagicMock()
+    mock_file.__enter__.return_value = mock_f
+    with patch(
+        "fastcs_odin.controllers.odin_data._generate_vds.h5py.File",
+        return_value=mock_file,
+    ):
+        create_interleave_vds(
+            Path(),
+            "test",
+            ["data"],
+            frame_count,
+            frames_per_block,
+            blocks_per_file,
+            (1, 1),
+            n_file_writers=n_file_writers,
+        )
+    layout: h5py.VirtualLayout = mock_f.create_virtual_dataset.call_args[0][1]
+    assert layout._src_filenames == expected_files
+    assert layout.shape == (frame_count, 1, 1)
+
+
+@patch("fastcs_odin.controllers.odin_data._generate_vds.h5py.VirtualSource")
+@patch("fastcs_odin.controllers.odin_data._generate_vds.h5py.VirtualLayout")
+@patch("fastcs_odin.controllers.odin_data._generate_vds.h5py.File")
+@pytest.mark.parametrize(
+    "frame_count, frames_per_block, blocks_per_file, expected_frames_per_file",
+    [
+        [155, 10, 3, [30, 30, 30, 30, 10, 10, 10, 5]],
+        [145, 10, 3, [30, 30, 30, 30, 10, 10, 5]],
+        [145, 10, 0, [40, 40, 35, 30]],
+        [145, 1, 0, [37, 36, 36, 36]],
+        [20, 30, 0, [20]],
+    ],
+)
+def test_create_interleave_cds_makes_expected_source_layout_calls(
+    mock_file: MagicMock,
+    mock_virtual_layoud: MagicMock,
+    mock_virtual_source: MagicMock,
+    frame_count: int,
+    frames_per_block: int,
+    blocks_per_file: int,
+    expected_frames_per_file: list[int],
+):
+    datasets = ["data", "sets"]
+    create_interleave_vds(
+        Path(),
+        "test",
+        datasets,
+        frame_count,
+        frames_per_block,
+        blocks_per_file,
+        (10, 10),
+    )
+    assert len(mock_virtual_source.call_args_list) == len(
+        expected_frames_per_file
+    ) * len(datasets)
+    for dataset_name in datasets:
+        for i, expected_frames in enumerate(expected_frames_per_file):
+            mock_virtual_source.assert_any_call(
+                f"test_00000{i + 1}.h5",
+                name=dataset_name,
+                shape=(expected_frames, 10, 10),
+                dtype="float",
+            )
+
+
+@pytest.mark.parametrize(
+    "frames, frames_per_block, expected_blocks, expected_remainder",
+    [[6, 3, 2, 0], [8, 3, 2, 2], [6, 7, 0, 6], [6, 6, 1, 0]],
+)
+def test_file_frames_dataclass_calculates_blocks_and_remainder_correctly(
+    frames: int, frames_per_block: int, expected_blocks, expected_remainder
+):
+    file_frames = FileFrames(frames=frames, frames_per_block=frames_per_block, start=0)
+    assert file_frames.blocks == expected_blocks
+    assert file_frames.remainder_frames == expected_remainder
+
+
+@pytest.mark.parametrize(
+    "frame_count, frames_per_block, blocks_per_file, n_writers, expected_distribution",
+    [
+        [
+            10,
+            3,
+            2,
+            1,
+            {
+                1: FileFrames(frames=6, frames_per_block=3, start=0),
+                2: FileFrames(frames=4, frames_per_block=3, start=6),
+            },
+        ],
+        [10, 10, 0, 4, {1: FileFrames(frames=10, frames_per_block=10, start=0)}],
+        [
+            985,
+            10,
+            0,
+            4,
+            {
+                1: FileFrames(frames=250, frames_per_block=10, start=0),
+                2: FileFrames(frames=250, frames_per_block=10, start=10),
+                3: FileFrames(frames=245, frames_per_block=10, start=20),
+                4: FileFrames(frames=240, frames_per_block=10, start=30),
+            },
+        ],
+        [
+            19,
+            2,
+            2,
+            4,
+            {
+                1: FileFrames(frames=4, frames_per_block=2, start=0),
+                2: FileFrames(frames=4, frames_per_block=2, start=2),
+                3: FileFrames(frames=4, frames_per_block=2, start=4),
+                4: FileFrames(frames=4, frames_per_block=2, start=6),
+                5: FileFrames(frames=2, frames_per_block=2, start=16),
+                6: FileFrames(frames=1, frames_per_block=2, start=18),
+            },
+        ],
+    ],
+)
+def test_calculate_frame_distribution(
+    frame_count: int,
+    frames_per_block: int,
+    blocks_per_file: int,
+    n_writers: int,
+    expected_distribution: dict[int, FileFrames],
+):
+    result = _calculate_frame_distribution(
+        frame_count, frames_per_block, blocks_per_file, n_writers
+    )
+    assert result == expected_distribution
+
+
+@pytest.fixture
+def mock_round_robin_data() -> tuple[list[np.ndarray], np.ndarray]:
+    """Assuming 4 file writers, 19 frames in blocks of 2 frames, and  2 blocks per file.
+    Frames are 2 x 2. The values in each frame represent the order they would have been
+    written in, and therefore the order the VDS should splice them together in."""
+    file1_data = np.array(
+        [
+            [[0, 0], [0, 0]],
+            [[1, 1], [1, 1]],
+            [[8, 8], [8, 8]],
+            [[9, 9], [9, 9]],
+        ]
+    )
+    file2_data = np.array(
+        [
+            [[2, 2], [2, 2]],
+            [[3, 3], [3, 3]],
+            [[10, 10], [10, 10]],
+            [[11, 11], [11, 11]],
+        ]
+    )
+    file3_data = np.array(
+        [
+            [[4, 4], [4, 4]],
+            [[5, 5], [5, 5]],
+            [[12, 12], [12, 12]],
+            [[13, 13], [13, 13]],
+        ]
+    )
+    file4_data = np.array(
+        [
+            [[6, 6], [6, 6]],
+            [[7, 7], [7, 7]],
+            [[14, 14], [14, 14]],
+            [[15, 15], [15, 15]],
+        ]
+    )
+    file5_data = np.array(
+        [
+            [[16, 16], [16, 16]],
+            [[17, 17], [17, 17]],
+        ]
+    )
+    file6_data = np.array(
+        [
+            [[18, 18], [18, 18]],
+        ]
+    )
+
+    expected_vds_data = np.array(
+        [
+            [[0, 0], [0, 0]],
+            [[1, 1], [1, 1]],
+            [[2, 2], [2, 2]],
+            [[3, 3], [3, 3]],
+            [[4, 4], [4, 4]],
+            [[5, 5], [5, 5]],
+            [[6, 6], [6, 6]],
+            [[7, 7], [7, 7]],
+            [[8, 8], [8, 8]],
+            [[9, 9], [9, 9]],
+            [[10, 10], [10, 10]],
+            [[11, 11], [11, 11]],
+            [[12, 12], [12, 12]],
+            [[13, 13], [13, 13]],
+            [[14, 14], [14, 14]],
+            [[15, 15], [15, 15]],
+            [[16, 16], [16, 16]],
+            [[17, 17], [17, 17]],
+            [[18, 18], [18, 18]],
+        ]
+    )
+    return [
+        file1_data,
+        file2_data,
+        file3_data,
+        file4_data,
+        file5_data,
+        file6_data,
+    ], expected_vds_data
+
+
+def test_create_interleave_vds_before_files_written(
+    tmp_path,
+    mock_round_robin_data: tuple[list[np.ndarray], np.ndarray],
+):
+    acquired_data, expected_vds_data = mock_round_robin_data
+    prefix = "test"
+
+    create_interleave_vds(tmp_path, prefix, ["data"], 19, 2, 2, (2, 2))
+
+    for i, data in enumerate(acquired_data):
+        with h5py.File(tmp_path / f"test_00000{i + 1}.h5", "w") as f:
+            f.create_dataset(name="data", data=data)
+
+    with h5py.File(f"{tmp_path / prefix}_vds.h5", "r") as f:
+        virtual_dataset = f.get("data")
+        assert isinstance(virtual_dataset, h5py.Dataset)
+        result = virtual_dataset[()]
+
+    assert np.array_equal(result, expected_vds_data)
+
+
+def test_create_interleave_vds_after_files_written(
+    tmp_path,
+    mock_round_robin_data: tuple[list[np.ndarray], np.ndarray],
+):
+    acquired_data, expected_vds_data = mock_round_robin_data
+    prefix = "test"
+
+    for i, data in enumerate(acquired_data):
+        with h5py.File(tmp_path / f"test_00000{i + 1}.h5", "w") as f:
+            f.create_dataset(name="data", data=data)
+
+    create_interleave_vds(tmp_path, prefix, ["data"], 19, 2, 2, (2, 2))
+
+    with h5py.File(f"{tmp_path / prefix}_vds.h5", "r") as f:
+        virtual_dataset = f.get("data")
+        assert isinstance(virtual_dataset, h5py.Dataset)
+        result = virtual_dataset[()]
+
+    assert np.array_equal(result, expected_vds_data)
+
+
+def test_create_interleave_vds_creates_virtual_dataset_for_all_datasets(
+    tmp_path,
+    mock_round_robin_data: tuple[list[np.ndarray], np.ndarray],
+):
+    acquired_data, expected_vds_data = mock_round_robin_data
+    prefix = "test"
+
+    for i, data in enumerate(acquired_data):
+        with h5py.File(tmp_path / f"test_00000{i + 1}.h5", "w") as f:
+            f.create_dataset(name="one", data=np.zeros(data.shape))
+            f.create_dataset(name="two", data=data * 10)
+            f.create_dataset(name="three", data=data * 100)
+
+    create_interleave_vds(tmp_path, prefix, ["one", "two", "three"], 19, 2, 2, (2, 2))
+
+    with h5py.File(f"{tmp_path / prefix}_vds.h5", "r") as f:
+        assert np.array_equal(f.get("one")[()], np.zeros(expected_vds_data.shape))  # type: ignore
+        assert np.array_equal(f.get("two")[()], expected_vds_data * 10)  # type: ignore
+        assert np.array_equal(f.get("three")[()], expected_vds_data * 100)  # type: ignore

--- a/uv.lock
+++ b/uv.lock
@@ -862,6 +862,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "fastcs", extra = ["epicsca"] },
+    { name = "h5py" },
 ]
 
 [package.dev-dependencies]
@@ -894,6 +895,7 @@ odin = [
 requires-dist = [
     { name = "aiohttp" },
     { name = "fastcs", extras = ["epicsca"], specifier = "~=0.12.0" },
+    { name = "h5py" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Moves VDS generation into fastcs-odin and does it on `stop_writing` instead of `start_writing`. 
Fixes https://github.com/DiamondLightSource/fastcs-eiger/issues/97, also relates to https://github.com/DiamondLightSource/fastcs-odin/issues/111
Requires https://github.com/DiamondLightSource/fastcs-eiger/pull/98